### PR TITLE
Fix to Sponsors Page for Mobile

### DIFF
--- a/sitedata/sponsors.yml
+++ b/sitedata/sponsors.yml
@@ -1,48 +1,59 @@
 sponsors:
 - tier: Diamond
   vals:
-  - {img: '<a href=''https://ai.facebook.com/''><img src=''https://iclr.cc/static/admin/img/sponsor_logos/facebook.png''
-      class=''sponsorLogo'' alt=''Facebook''></a><br>', name: Facebook}
-  - {img: '<a href=''https://research.google''><img src=''https://iclr.cc/static/admin/img/sponsor_logos/google-iclr-2020.png''
-      class=''sponsorLogo'' alt=''Google''></a><br>', name: Google}
-  - {img: '<a href=''http://www.deepmind.com''><img src=''https://iclr.cc/static/admin/img/sponsor_logos/DeepMind-nips-2019.png''
-      class=''sponsorLogo'' alt=''DeepMind''></a><br>', name: DeepMind}
+    - name: Facebook
+      img_url: https://ai.facebook.com/
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/facebook.png
+    - name: Google
+      img_url: https://research.google
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/google-iclr-2020.png
+    - name: DeepMind
+      img_url: http://www.deepmind.com
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/DeepMind-nips-2019.png
 - tier: Gold
   vals:
-  - {img: '<a href=''https://www.janestreet.com/''><img src=''https://iclr.cc/static/admin/img/sponsor_logos/jane-street-nips-2018.png''
-      class=''sponsorLogo'' alt=''Jane Street''></a><br>', name: Jane Street}
-  - {img: '<a href=''https://einstein.ai/''><img src=''https://iclr.cc/static/admin/img/sponsor_logos/salesforce-2017.png''
-      class=''sponsorLogo'' alt=''Salesforce''></a><br>', name: Salesforce}
-  - {img: '<a href=''https://www.amazon.jobs/en/landing_pages/ICLR''><img src=''https://iclr.cc/static/admin/img/sponsor_logos/amazon-icml-2018.png''
-      class=''sponsorLogo'' alt=''Amazon''></a><br>', name: Amazon}
-  - {img: '<a href=''https://openai.com/''><img src=''https://iclr.cc/static/admin/img/sponsor_logos/openai-iclr-2019.png''
-      class=''sponsorLogo'' alt=''OpenAI''></a><br>', name: OpenAI}
-  - {img: '<a href=''https://www.research.ibm.com/artificial-intelligence/''><img
-      src=''https://iclr.cc/static/admin/img/sponsor_logos/ibm-nips-2019.png'' class=''sponsorLogo''
-      alt=''IBM Research''></a><br>', name: IBM Research}
+    - name: Jane Street
+      img_url: https://www.janestreet.com/
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/jane-street-nips-2018.png
+    - name: Salesforce
+      img_url: https://einstein.ai/
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/salesforce-2017.png
+    - name: Amazon
+      img_url: https://www.amazon.jobs/en/landing_pages/ICLR
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/amazon-icml-2018.png
+    - name: OpenAI
+      img_url: https://openai.com/
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/openai-iclr-2019.png
+    - name: IBM Research
+      img_url: https://www.research.ibm.com/artificial-intelligence/
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/ibm-nips-2019.png
 - tier: Silver
   vals:
-  - {img: '<a href=''https://www.alibabagroup.com/en/about/overview''><img src=''https://iclr.cc/static/admin/img/sponsor_logos/alibaba.png''
-      class=''sponsorLogo'' alt=''Alibaba Group''></a><br>', name: Alibaba Group}
-  - {img: '<a href=''https://www.apple.com/jobs/us/teams/machine-learning-and-ai.html''><img
-      src=''https://iclr.cc/static/admin/img/sponsor_logos/apple-nips-2019.png'' class=''sponsorLogo''
-      alt=''Apple''></a><br>', name: Apple}
-  - {img: '<a href=''http://www.microsoft.com/research''><img src=''https://iclr.cc/static/admin/img/sponsor_logos/microsoft-nips-2018.png''
-      class=''sponsorLogo'' alt=''Microsoft''></a><br>', name: Microsoft}
-  - {img: '<a href=''http://www.bytedance.com''><img src=''https://iclr.cc/static/admin/img/sponsor_logos/
-      ByteDance-nips-2019.png'' class=''sponsorLogo'' alt=''ByteDance''></a><br>',
-    name: ByteDance}
+    - name: Alibaba Group
+      img_url: https://www.alibabagroup.com/en/about/overview
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/alibaba.png
+    - name: Apple
+      img_url: https://www.apple.com/jobs/us/teams/machine-learning-and-ai.html
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/apple-nips-2019.png
+    - name: Microsoft
+      img_url: http://www.microsoft.com/research
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/microsoft-nips-2018.png
+    - name: ByteDance
+      img_url: http://www.bytedance.com
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/ByteDance-nips-2019.png
 - tier: Bronze
   vals:
-  - {img: '<a href=''http://www.deshaw.com''><img src=''https://iclr.cc/static/admin/img/sponsor_logos/de_shaw-iclr-2019.png''
-      class=''sponsorLogo'' alt=''The D. E. Shaw Group''></a><br>', name: The D. E.
-      Shaw Group}
-  - {img: '<a href=''http://www.twosigma.com''><img src=''https://iclr.cc/static/admin/img/sponsor_logos/two_sigma.png''
-      class=''sponsorLogo'' alt=''Two Sigma''></a><br>', name: Two Sigma}
-  - {img: '<a href=''https://lambdalabs.com/''><img src=''https://iclr.cc/static/admin/img/sponsor_logos/lambda-nips-2017.png''
-      class=''sponsorLogo'' alt=''Lambda''></a><br>', name: Lambda}
+    - name: The D. E. Shaw Group
+      img_url: http://www.deshaw.com
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/de_shaw-iclr-2019.png
+    - name: Two Sigma
+      img_url: http://www.twosigma.com/
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/two_sigma.png
+    - name: Lambda
+      img_url: https://lambdalabs.com/
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/lambda-nips-2017.png
 - tier: Start-Up Companies
   vals:
-  - {img: '<a href=''http://www.elementai.com''><img src=''https://iclr.cc/static/admin/img/sponsor_logos/element-ai-2017.png''
-      class=''sponsorLogo'' alt=''Element AI''></a><br>', name: Element AI}
-
+    - name: Element AI
+      img_url: http://www.elementai.com
+      img_src: https://iclr.cc/static/admin/img/sponsor_logos/element-ai-2017.png

--- a/templates/pages/sponsors.html
+++ b/templates/pages/sponsors.html
@@ -29,9 +29,7 @@
     <div class="col-4 p-2" style="display: flex;flex-flow:wrap; margin-left:0; box-sizing: border-box;">
       <div class="card "style="display:block; overflow:hidden; width:100%;">
         <div class="card-header d-flex flex-wrap justify-content-center align-items-center" style="height: 250px;">
-          
-            {{sponsor.img|safe}}
-          
+            <a href="{{sponsor.img_url}}"><img src="{{sponsor.img_src}}" class="sponsorLogo" alt="{{sponsor.name}}" /></a>
         </div>
       </div>
       </div>

--- a/templates/pages/sponsors.html
+++ b/templates/pages/sponsors.html
@@ -22,18 +22,17 @@
         <h3 class=""> {{section.tier}} </h2>
       </div>
     </div>
-    <div class="row">
+    <div class="row justify-content-start">
     {% set rowloop = loop.index %}
-
-    {% for sponsor in section.vals %}
-    <div class="col-4 p-2" style="display: flex;flex-flow:wrap; margin-left:0; box-sizing: border-box;">
-      <div class="card "style="display:block; overflow:hidden; width:100%;">
-        <div class="card-header d-flex flex-wrap justify-content-center align-items-center" style="height: 250px;">
-            <a href="{{sponsor.img_url}}"><img src="{{sponsor.img_src}}" class="sponsorLogo" alt="{{sponsor.name}}" /></a>
+      {% for sponsor in section.vals %}
+      <div class="col-lg-4 col-md-6 col-xs-12 p-2" style="display: flex;flex-flow:wrap; margin-left:0; box-sizing: border-box;">
+        <div class="card "style="display:block; overflow:hidden; width:100%;">
+          <div class="card-header d-flex flex-wrap justify-content-center align-items-center" style="height: 250px;">
+              <a href="{{sponsor.img_url}}"><img src="{{sponsor.img_src}}" class="sponsorLogo" alt="{{sponsor.name}}" /></a>
+          </div>
         </div>
-      </div>
-      </div>
-    {% endfor %}
+        </div>
+      {% endfor %}
     </div>
     {% endfor %}
     </div>


### PR DESCRIPTION
Regarding #12 I have made minimal changes to the layout of the sponsors page to make it look a bit better on mobile.

Also the schema of the `sponsors.yml` was a bit strange and limiting so I changed it.

Here are some before and after snapshots of the sponsors page.

Before | After
------------ | -------------
Large Screen | Large Screen
![before-large](https://user-images.githubusercontent.com/289031/79358911-28f5fc00-7f42-11ea-9aa2-8f96ea1135b3.png) | ![after-large](https://user-images.githubusercontent.com/289031/79358933-3317fa80-7f42-11ea-913f-cfa4b1de0750.png)
iPhone Vertical | iPhone Vertical
![before-iphone-vertical](https://user-images.githubusercontent.com/289031/79359048-5cd12180-7f42-11ea-8f0d-f50848c303ac.png) | ![after-iphone-vertical](https://user-images.githubusercontent.com/289031/79359062-62c70280-7f42-11ea-8105-ccde52f047a6.png)
iPhone Horizontal | iPhone Horizontal
![before-iphone-horizontal](https://user-images.githubusercontent.com/289031/79359125-77a39600-7f42-11ea-8996-81e4bcee1146.png) |  ![after-iphone-horizontal](https://user-images.githubusercontent.com/289031/79359135-7bcfb380-7f42-11ea-92dc-67508614fae7.png)
iPad | iPad
![before-ipad](https://user-images.githubusercontent.com/289031/79359166-88540c00-7f42-11ea-826a-c3f42bc47b62.png) | ![after-ipad](https://user-images.githubusercontent.com/289031/79359176-8c802980-7f42-11ea-97cf-ab4067347709.png)

Here is a video showing it in action: [video link](https://www.dropbox.com/s/r5khf8dta8le5ro/after.mov?dl=0)
