### PR TITLE
Small Fix for Index Header in Mobile

### DIFF
--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -31,8 +31,8 @@
           </div>
         </div>
         
-        <div class=" row header p-5">
-          <div class="p-1 mx-auto text-center text-white col-md-4 col-sm-12" >
+        <div class=" row header">
+          <div class="p-1 mx-auto text-center text-white col-md-9 col-sm-12" >
             <h2 style:"">
                           EIGHTH
                           INTERNATIONAL


### PR DESCRIPTION
Related to #12.
There was a small typographic issue in the header of the home page in mobile. The text seemed a bit off to the right.

I have made very minimal changes that makes it look a bit better.

Before | After
------------ | -------------
Large Screen | Large Screen
![before-full](https://user-images.githubusercontent.com/289031/79698489-8fa05000-8289-11ea-9257-e19fd044de42.png) | ![after-full](https://user-images.githubusercontent.com/289031/79698493-99c24e80-8289-11ea-80d8-8221ae862831.png)
iPhone Vertical | iPhone Vertical
![before-iphone](https://user-images.githubusercontent.com/289031/79698501-ab0b5b00-8289-11ea-838b-30a027b64d83.png) | ![after-iphone](https://user-images.githubusercontent.com/289031/79698504-afd00f00-8289-11ea-9310-823a19e3fc5a.png)
iPad | iPad
![before-ipad](https://user-images.githubusercontent.com/289031/79698518-bfe7ee80-8289-11ea-835d-e868e5b2a795.png) | ![after-ipad](https://user-images.githubusercontent.com/289031/79698523-c4aca280-8289-11ea-9e2e-14cab34020d8.png)

