### PR TITLE
Workshop papers without search

### DIFF
--- a/main.py
+++ b/main.py
@@ -256,7 +256,12 @@ def speakers():
 @app.route('/workshops_<workshop>.html')
 def workshop(workshop):
     return render_template('pages/workshop.html',
-                           **{"info":site_data["workshops"]["workshops"][int(workshop) -1 ] })
+                           **{"info":site_data["workshops"]["workshops"][int(workshop) -1 ]})
+
+@app.route('/workshop_papers_<workshop>.html')
+def workshop_papers(workshop):
+	return render_template('pages/workshop_papers.html',
+							**{"papers":site_data["workshop_papers"]["workshop_papers"][workshop]})
 
 @app.route('/speaker_<speaker>.html')
 def speaker(speaker):

--- a/sitedata/workshop_papers.yml
+++ b/sitedata/workshop_papers.yml
@@ -1,0 +1,50 @@
+workshop_papers:
+  FSAI:
+    - title: Paper1
+      authors: "Author 1, Author 2"
+    - title: Paper2
+      authors: "Author 1, Author 2"
+    - title: Paper3
+      authors: "Author 1, Author 2"
+  ai4cc:
+    - title: Paper1
+      authors: "Author 1, Author 2"
+  ai4earthscience:
+    - title: Paper1
+      authors: "Author 1, Author 2"
+  BAICS:
+    - title: Paper1
+      authors: "Author 1, Author 2"
+  deepdiffeq:
+    - title: Paper1
+      authors: "Author 1, Author 2"
+  trustworthy:
+    - title: Paper1
+      authors: "Author 1, Author 2"
+  climatechange:
+    - title: Paper1
+      authors: "Author 1, Author 2"
+  MLIRL:
+    - title: Paper1
+      authors: "Author 1, Author 2"
+  NAS:
+    - title: Paper1
+      authors: "Author 1, Author 2"
+  AfricaNLP:
+    - title: Paper1
+      authors: "Author 1, Author 2"
+  ai4ah:
+    - title: Paper1
+      authors: "Author 1, Author 2"
+  betrrl:
+    - title: Paper1
+      authors: "Author 1, Author 2"
+  CV4A:
+    - title: Paper1
+      authors: "Author 1, Author 2"
+  causallearning:
+    - title: Paper1
+      authors: "Author 1, Author 2"
+  pml4dc:
+    - title: Paper1
+      authors: "Author 1, Author 2"

--- a/templates/pages/workshop.html
+++ b/templates/pages/workshop.html
@@ -34,6 +34,9 @@
        <a href="chat.html?room=channel/workshop_{{info.chat}}" target="_blank"  class="card-link">
            Chat
        </a>
+       <a href="workshop_papers_{{info.chat}}.html" target="_blank" class="card-link">
+            Papers
+       </a>
 
        
      </div>

--- a/templates/pages/workshop_papers.html
+++ b/templates/pages/workshop_papers.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+
+{% set page_title = "Workshop" %}
+{% include 'pages/head.html' %}
+
+<body>
+  <script src="https://unpkg.com/@popperjs/core@2"></script>
+  <script src="https://unpkg.com/tippy.js@6"></script>
+  <!-- NAV -->
+  {% set active_page = "Workshops" %}
+  {% include 'pages/header.html' %}
+
+  <div class="container">
+
+    <div class="row"></div>
+
+    
+    <div class="cards row">
+      {% for paper in papers %}
+      <div class="myCard col-xs-6 col-md-4">
+        <div class="pp-card pp-mode-list">
+          <div class="pp-card-header">
+            <a href="poster_${openreview.content.iclr_id}.html"
+            class="text-muted">
+            <h5 class="card-title" align="center"> {{paper.title}} </h5></a>
+            <h6 class="card-subtitle text-muted" align="center">
+              {{paper.authors}}
+            </h6>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+
+  </div>
+  <script src="static/js/typeahead_tools.js"></script>
+  <script src="static/js/papers.js"></script>
+
+  {% include 'pages/footer.html' %}
+</body>


### PR DESCRIPTION
A very simple listing of workshop papers. 
Since the workshop site has a SlidesLive and RocketChat, what would the poster_.html have (which you had mentioned in you comment on the issue #27).
Could someone help with the search? If a yml file is used for storage (as it is now), quite a few js files will need to be duplicated with slight changes. Otherwise, a json like papers.json can be used but I don't know how it was generated.