### PR TITLE
change "video chat" to "zoom meeting"

### DIFF
--- a/templates/pages/page.html
+++ b/templates/pages/page.html
@@ -67,7 +67,7 @@
 
      <div class=" text-center text-muted text-monospace">
        {% for session in openreview.content.session %}
-       <div> {{session}} {% if openreview.content.session_times[loop.index - 1] != None%} {{openreview.content.session_times[loop.index - 1]}} [<a href="" target="_blank"  class="card-link">Video Chat</a>] {% endif %}
+       <div> {{session}} {% if openreview.content.session_times[loop.index - 1] != None%} {{openreview.content.session_times[loop.index - 1]}} [<a href="" target="_blank"  class="card-link">Zoom Meeting</a>] {% endif %}
        </div>
        {% endfor %}
      </div>


### PR DESCRIPTION
"Video Chat" was pointed out as confusing, because "Chat" button for rocket.chat is just above.