### PR TITLE
fix: remove double media frames

### DIFF
--- a/templates/pages/page.html
+++ b/templates/pages/page.html
@@ -68,24 +68,6 @@
           <p></p>
         </div>
       </div>
-    </div>
-    <!-- SlidesLive -->
-    <div class="container" style="background-color:white; padding: 0px;">
-    <div class="row m-2">
-      <div class="col-md-7 col-xs-12 my-auto p-2" >
-        <div id="presentation-embed-38915748" class="slp my-auto"></div>
-        <script src='https://slideslive.com/embed_presentation.js'></script>
-        <script>
-          embed = new SlidesLiveEmbed('presentation-embed-38915748', {
-          presentationId: '38915748',
-          autoPlay: false, // change to true to autoplay the embedded presentation
-          verticalEnabled: true,
-          verticalWhenWidthLte: 2000,
-          allowHiddenControlsWhenPaused: true,
-          hideTitle: true
-          });
-        </script>
-      </div>
       <!-- SlidesLive -->
       <div class="container" style="background-color:white; padding: 0px;">
         <div class="row m-2">
@@ -112,34 +94,34 @@
           </div>
         </div>
       </div>
-    </div>
-    <!-- Recs -->
-    <p></p>
-    <div  class="container" style="padding-bottom: 30px; padding-top:30px">
-      <center>
-        <h2> Similar Papers </h2>
-      </center>
-    </div>
-    <p></p>
-    <div  class="container" >
-      <div class="row">
-        {% for openreview in paper_recs %}
-        <div class="col-md-4 col-xs-6">
-          <div class="pp-card" >
-            <div class="pp-card-header" class="text-muted">
-              <a href="poster_{{openreview.content.iclr_id}}.html" class="text-muted">
-                <h5 class="card-title" align="center">{{openreview.content.title}}</h5>
-              </a>
-              <h6 class="card-subtitle text-muted" align="center">
-                {% for a in openreview.content.authors %}
-                {{a}},
-                {% endfor %}
-              </h6>
-              <center><img class="cards_img" src="https://iclr.github.io/iclr-images/{{openreview.content.iclr_id}}.png" width="80%"/></center>
+      <!-- Recs -->
+      <p></p>
+      <div  class="container" style="padding-bottom: 30px; padding-top:30px">
+        <center>
+          <h2> Similar Papers </h2>
+        </center>
+      </div>
+      <p></p>
+      <div  class="container" >
+        <div class="row">
+          {% for openreview in paper_recs %}
+          <div class="col-md-4 col-xs-6">
+            <div class="pp-card" >
+              <div class="pp-card-header" class="text-muted">
+                <a href="poster_{{openreview.content.iclr_id}}.html" class="text-muted">
+                  <h5 class="card-title" align="center">{{openreview.content.title}}</h5>
+                </a>
+                <h6 class="card-subtitle text-muted" align="center">
+                  {% for a in openreview.content.authors %}
+                  {{a}},
+                  {% endfor %}
+                </h6>
+                <center><img class="cards_img" src="https://iclr.github.io/iclr-images/{{openreview.content.iclr_id}}.png" width="80%"/></center>
+              </div>
             </div>
           </div>
+          {% endfor %}
         </div>
-        {% endfor %}
       </div>
     </div>
     {% include 'pages/footer.html' %}


### PR DESCRIPTION
This PR addresses the issue where two media frames are displayed instead of one. Here is an [example link](https://iclr.cc/virtual/poster_H1xscnEKDr.html) exhibiting this issue.

I feel like I might have made a dumb mistake while merging earlier. This PR should fix it.