### PR TITLE
edit: remove reference to Help menu

### DIFF
--- a/sitedata/faq.yml
+++ b/sitedata/faq.yml
@@ -60,7 +60,7 @@ FAQ:
       - Question: What do I do if I have been allocated a poster session that is at a bad time for me? 
         Answer: "Each author was given the chance to sign up, on iclr.cc, for two timezones. If you did not fill in the form, we allocated you to remaining sessions. In some cases, authors may have to present outside typical working hours; this is not ideal, but is difficult to avoid for a global virtual conference. We know we are asking a lot of you, and really appreciate your understanding. If you cannot present your poster, you could try to find another author to present the work. If there is absolutely no way for you to present your work (we know childcare is an issue right now), please reach out to us at iclr2020programchairs@googlegroups.com."
       - Question: I’m an author and think my paper has been accidentally left out of the program, but I can’t find my paper. What should I do?
-        Answer: "If you can’t find your paper because of difficulty navigating the website, please contact the help desk at #helpdesk on Rocket.Chat (go to Help menu).  If you still can’t find a resolution, then the likely issue is that your email address for you paper on OpenReview is not associated with your ICLR account. Contact the organisers at iclr2020-virtual-at- googlegroups.com"
+        Answer: "If you can’t find your paper because of difficulty navigating the website, please contact the help desk at #helpdesk on Rocket.Chat (click on Tech Support on the top of this page).  If you still can’t find a resolution, then the likely issue is that your email address for you paper on OpenReview is not associated with your ICLR account. Contact the organisers at iclr2020-virtual-at-googlegroups.com"
           
   - Section: General
     QA:


### PR DESCRIPTION
The current FAQ misleadingly directs participants to go to the Help menu (when in fact they are already on the FAQ page of the Help menu). This PR edits out the relevant portion and replaces it with an updated description. 