### PR TITLE
Add Highwire Press meta tags for citation info

### DIFF
--- a/templates/pages/page.html
+++ b/templates/pages/page.html
@@ -2,6 +2,17 @@
 <html lang="en">
   {% set page_title = "ICLR: " + openreview.content.title %}
   {% include 'pages/head.html' %}
+  <meta name="citation_title" content="{{openreview.content.title}}" />
+  {% for author in openreview.content.authors %}
+  <meta name="citation_author" content="{{author}}" />
+  {% endfor %}
+  <meta name="citation_publication_date" content="2020/04"/>
+  <meta name="citation_conference_title" content="Eighth International Conference on Learning Representations" />
+  <meta name="citation_abstract" content="{{openreview.content.abstract}}" />
+  <meta name="citation_pdf_url" content="http://www.openreview.net/pdf?id={{openreview.forum}}" />
+  {% for keyword in openreview.content.keywords %}
+  <meta name="citation_keywords" content="{{keyword}}" />
+  {% endfor %}
   <body >
     <!-- NAV -->
     {% include 'pages/header.html' %}


### PR DESCRIPTION
These tags are useful for importing papers into citation manager with all the necessary metadata. Previously, the Zotero importer isn't able to pull in any metadata or download the PDF from a paper's page ([example](https://iclr.cc/virtual/poster_r1xMH1BtvB.html)); with this change the following is pulled (plus the PDF):

![image](https://user-images.githubusercontent.com/1337259/80363785-a132ba80-887c-11ea-9de4-f5fb63711452.png)

The HTML generated after `bash freeze.sh` looks reasonable (meta tags are pulled to the `<head>`). 

Not sure how useful this is, but was quick to put together. Understandable if you don't want to rebuild the site mid-conference :)